### PR TITLE
Added decamelize options + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ This should output the following XML document:
 * `manifest`: Whether or not to add that XML manifest line to the top
 * `unwrappedArrays`: TODO: Document
 * `filterNulls`: Should nulls and undefines be removed from the rendered XML
+* `decamelize`: Should camel case names of elements and attributes be converted for example `someAttr` -> `some-attr`, separator is `-` by default or not empty value of `decamelize`, default: `false`
+* `decamelizeAttributes`: The same as `decamelize` but only for attributes , default: `false`
+* `decamelizeElements`: The same as `decamelize` but only for elements, default: `false`
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ var ElementTree = et.ElementTree;
 var element = et.Element;
 var subElement = et.SubElement;
 
+var decamelize = function (str, sep) {
+    return str.replace(/([a-z\d])([A-Z])/g, '$1' + (sep || '-') + '$2').toLowerCase();
+};
+
 /**
  * Instantiate a new EasyXml instance
  *
@@ -24,7 +28,10 @@ var EasyXml = function(config) {
         manifest: false,
         unwrappedArrays: false,
         indent: 4,
-        filterNulls: false
+        filterNulls: false,
+        decamelize: false,
+        decamelizeAttributes: false,
+        decamelizeElements: false
     }, config);
 };
 
@@ -151,6 +158,10 @@ EasyXml.prototype.parseChildElement = function(parentXmlNode, parentObjectNode) 
             if (this.filterNull(child)) {
                 // no element if we are skipping nulls and undefined
                 continue;
+            }
+
+            if (this.config.decamelize || this.config.decamelizeAttributes || this.config.decamelizeElements){
+                key = decamelize(key, (this.isAttribute(key) ? this.config.decamelizeAttributes : this.config.decamelizeElements) || this.config.decamelize)
             }
 
             if (!isNaN(key)) {

--- a/index.js
+++ b/index.js
@@ -161,7 +161,8 @@ EasyXml.prototype.parseChildElement = function(parentXmlNode, parentObjectNode) 
             }
 
             if (this.config.decamelize || this.config.decamelizeAttributes || this.config.decamelizeElements){
-                key = decamelize(key, (this.isAttribute(key) ? this.config.decamelizeAttributes : this.config.decamelizeElements) || this.config.decamelize)
+                var separator = (this.isAttribute(key) ? this.config.decamelizeAttributes : this.config.decamelizeElements) || this.config.decamelize;
+                key = decamelize(key, typeof separator == 'string' ? separator : '-')
             }
 
             if (!isNaN(key)) {

--- a/test/fixtures/decamelize.json
+++ b/test/fixtures/decamelize.json
@@ -1,0 +1,5 @@
+{
+  "goodPerson": {
+    "_lastName": "Galt"
+  }
+}

--- a/test/fixtures/decamelize.xml
+++ b/test/fixtures/decamelize.xml
@@ -1,0 +1,3 @@
+<response>
+    <good-person last-name="Galt" />
+</response>

--- a/test/tests.js
+++ b/test/tests.js
@@ -17,14 +17,16 @@ describe("Node EasyXML", function () {
     wrappedArrays: "should normally wrap array elements in a single parent element",
     'null': "should parse a null value",
     rootArray1: "should work as expected when root is an array of objects",
-    rootArray2: "should work as expected when root is an array of strings"
+    rootArray2: "should work as expected when root is an array of strings",
+    decamelize: "should parse a JSON object using decamelize option"
   };
 
   Object.keys(should).forEach(function(name) {
-      it(should[name], function(done) {
+      it.only(should[name], function(done) {
         var config = {
           singularizeChildren: name !== 'singularizeChildren' && name !== 'singularizeChildren2',
-          unwrappedArrays: name === 'unwrappedArrays'
+          unwrappedArrays: name === 'unwrappedArrays',
+          decamelize: name === 'decamelize'
         };
 
         var easyXML = new EasyXml(config);


### PR DESCRIPTION
Added `decamelize` option that alows turn camelCase names to something different:

`xmlnsAndroid` -> `xmlns:android` if `decamelize` is set to `:`
