### PR TITLE
MAJOR change. Serialize moment.js, and other objects with .toJSON()

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,8 +232,13 @@ EasyXml.prototype.parseChildElement = function(parentXmlNode, parentObjectNode) 
                     }
                 }
             } else if (typeof child === 'object') {
-                // Object, go deeper
-                this.parseChildElement(el, child);
+                if (typeof child.toJSON === 'function') {
+                    // .toJSON() is a common JS convention for serializing an object
+                    el.text = child.toJSON();
+                } else {
+                    // Object, go deeper
+                    this.parseChildElement(el, child);
+                }
             } else if (typeof child === 'number' || typeof child === 'boolean') {
                 el.text = child.toString();
                 /* istanbul ignore else */

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "inflect": "^0.3.0"
   },
   "devDependencies": {
-    "mocha": "^2.0.1"
+    "mocha": "^2.0.1",
+    "moment": "^2.11.2"
   },
   "license": "(BSD-3-Clause OR GPL-2.0)",
   "engines": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,7 @@
 var assert  = require('assert');
 var fs = require('fs');
 var EasyXml = require('../index.js');
+var moment = require('moment');
 
 describe("Node EasyXML", function () {
   var should = {
@@ -206,5 +207,17 @@ describe("Node EasyXML", function () {
       var after = easyXML.render(before, 'Kennel');
 
       assert.equal(after, "<Kennel>\n<dog>\n<name>spot</name>\n</dog>\n<dog>\n<name>rover</name>\n</dog>\n</Kennel>\n");
+    });
+
+    it("properly serializes a moment.js object", function() {
+      var before = {
+        date: moment("2016-02-06 21:03:00")
+      };
+
+      var easyXML = new EasyXml();
+
+      var after = easyXML.render(before);
+
+      assert.equal(after, "<response>\n    <date>2016-02-07T05:03:00.000Z</date>\n</response>\n");
     });
 });


### PR DESCRIPTION
A lot of objects have a `.toJSON()` method. This will change output for old applications. MAJOR change.

This will fix issue #2.
